### PR TITLE
add missing library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ opencv-python
 chumpy
 yacs
 rtree
+lpips


### PR DESCRIPTION
Thanks for sharing this wonderful code.
I added 'lpips' library to prevent this error.

python test.py --ckpt_path checkpoints/male-3-casual_refine/last.ckpt --vis
Traceback (most recent call last):
  File "test.py", line 17, in <module>
    from lpips import LPIPS
ModuleNotFoundError: No module named 'lpips'
